### PR TITLE
Mapfix

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -29298,14 +29298,14 @@
 	name = "Privacy Shutters Control";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = "28"
+	req_access_txt = "57"
 	},
 /obj/machinery/button/door{
 	id = "hopqueue";
 	name = "Queue Shutters Control";
 	pixel_x = -4;
 	pixel_y = 25;
-	req_access_txt = "28"
+	req_access_txt = "57"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -4;
@@ -63895,6 +63895,13 @@
 /obj/machinery/vending/snack/kitchen,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
+"cHN" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel{
+	icon_state = "red";
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 
 (1,1,1) = {"
 aaa
@@ -111557,9 +111564,9 @@ cEB
 cEI
 cEg
 aNA
-aCB
-aPX
-aCB
+aFi
+aFi
+aFi
 aSD
 aFi
 aVl
@@ -111814,8 +111821,8 @@ cEB
 cEI
 aCB
 aCB
-aOL
-aPW
+aCB
+aCB
 aCB
 aCB
 aCB
@@ -112071,9 +112078,9 @@ cEC
 cEI
 cEN
 aMC
-aCB
-aCB
-aCB
+aOM
+aPY
+aMD
 aSF
 aUc
 aVm
@@ -112328,8 +112335,8 @@ cEz
 cEI
 cEO
 aMC
-aOM
-aPY
+cHN
+cFb
 aMD
 aSE
 aON

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -8021,6 +8021,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/item/weapon/staplegun,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aqT" = (
@@ -19353,6 +19354,7 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
+/obj/item/weapon/staplegun,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aQv" = (
@@ -33389,6 +33391,7 @@
 	pixel_x = 6;
 	pixel_y = -5
 	},
+/obj/item/weapon/staplegun,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buR" = (
@@ -63902,6 +63905,11 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
+"cHO" = (
+/obj/structure/table/wood,
+/obj/item/weapon/staplegun,
+/turf/open/floor/wood,
+/area/library)
 
 (1,1,1) = {"
 aaa
@@ -108999,7 +109007,7 @@ aPQ
 aRm
 aIa
 aTW
-aKL
+cHO
 aYk
 aYk
 aVg


### PR DESCRIPTION
:cl: Pyko
del: removed the remains of old chapel obstructing doorways.
fix: Hop shutter now properly ask for hop access instead of kitchen.
add: Staplers to cargo, library, law office and art supply storage.
/:cl: