### PR TITLE
Adds two freon canisters to science.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -36782,6 +36782,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plasteel/floorgrime,
 /area/toxins/storage)
 "bBU" = (
@@ -36809,6 +36810,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plasteel/floorgrime,
 /area/toxins/storage)
 "bBY" = (


### PR DESCRIPTION
It's time to free Freon friends.
:cl: Esumlogos
add: Two Freon canisters have been added to Toxins Storage in Science. Careful! Freon is just as dangerous as Plasma is, just colder.
 /:cl: