### PR TITLE
Removes Mass Hallucination event from rotation

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/mass_hallucination
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
-	weight = 0
-	max_occurrences = 2
+	weight = 7
+	max_occurrences = 0
 	min_players = 1
 
 /datum/round_event/mass_hallucination/start()

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/mass_hallucination
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
-	weight = 7
+	weight = 0
 	max_occurrences = 2
 	min_players = 1
 


### PR DESCRIPTION
🆑 PopNotes
fix: The Mass Hallucination random event is temporarily out of rotation due to causing crashes.
/🆑

This should be a temporary change, revert once the bug is squashed.