### PR TITLE
Raises the blob win cap.

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -32,7 +32,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	var/blob_point_rate = 3
 	var/blob_base_starting_points = 80
 
-	var/blobwincount = 250
+	var/blobwincount = 500
 
 	var/messagedelay_low = 2400 //in deciseconds
 	var/messagedelay_high = 3600 //blob report will be sent after a random value between these (minimum 4 minutes, maximum 6 minutes)
@@ -42,7 +42,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 /datum/game_mode/blob/pre_setup()
 	cores_to_spawn = max(round(num_players()/players_per_core, 1), 1)
 
-	var/win_multiplier = 1 + (0.1 * cores_to_spawn)
+	var/win_multiplier = 1 + (0.2 * cores_to_spawn)
 	blobwincount = initial(blobwincount) * cores_to_spawn * win_multiplier
 
 	for(var/j = 0, j < cores_to_spawn, j++)


### PR DESCRIPTION
Blob rounds seem to be over in less time than it takes for the shuttle to go away and come back with a paltry amount of lasers. This doubles their cap in order to give the crew time to mount a defence, (or achieve new levels of stupid)

:cl: GuyonBroadway
tweak: Roughly doubles the tiles it takes for the blob to win.
/:cl:

