### PR TITLE
Removes the detain function from standard secbots (but not ED-209s)

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2092,9 +2092,9 @@
 	},
 /mob/living/simple_animal/bot/secbot{
 	baton_type = /obj/item/weapon/melee/baton;
-	desc = "It's Officer Camille! Would have an itchy trigger finger if he had hands.";
+	desc = "It's Officer Camile! Would have an itchy trigger finger if he had hands."; //apparently intentional typo
 	idcheck = 1;
-	name = "\improper Officer Camille";
+	name = "\improper Officer Camile";
 	radio_key = /obj/item/device/encryptionkey/secbot;
 	weaponscheck = 1
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2091,11 +2091,10 @@
 	tag = ""
 	},
 /mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
 	baton_type = /obj/item/weapon/melee/baton;
-	desc = "It's Officer Camile! Would have an itchy trigger finger if he had hands.";
+	desc = "It's Officer Camille! Would have an itchy trigger finger if he had hands.";
 	idcheck = 1;
-	name = "\improper Officer Camile";
+	name = "\improper Officer Camille";
 	radio_key = /obj/item/device/encryptionkey/secbot;
 	weaponscheck = 1
 	},
@@ -64288,7 +64287,6 @@
 	dir = 1
 	},
 /mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
 	baton_type = /obj/item/weapon/melee/baton;
 	desc = "It's Officer Cappy! Would have an itchy trigger finger if he had hands.";
 	idcheck = 1;

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -102,7 +102,6 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 Arrest Unidentifiable Persons: []<BR>
 Arrest for Unauthorized Weapons: []<BR>
 Arrest for Warrant: []<BR>
-Operating Mode: []<BR>
 Report Arrests[]<BR>
 Auto Patrol: []"},
 
@@ -279,10 +278,7 @@ Auto Patrol: []"},
 
 			if(iscarbon(target) && target.canBeHandcuffed())
 				if(!target.handcuffed)  //he's not cuffed? Try to cuff him!
-						cuff(target)
-					else
-						back_to_idle()
-						return
+					cuff(target)
 			else
 				back_to_idle()
 				return

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -30,7 +30,6 @@
 	var/idcheck = 0 //If true, arrest people with no IDs
 	var/weaponscheck = 0 //If true, arrest people for weapons if they lack access
 	var/check_records = 1 //Does it check security records?
-	var/arrest_type = 0 //If true, don't handcuff
 
 /mob/living/simple_animal/bot/secbot/beepsky
 	name = "Officer Beep O'sky"
@@ -110,7 +109,6 @@ Auto Patrol: []"},
 "<A href='?src=\ref[src];operation=idcheck'>[idcheck ? "Yes" : "No"]</A>",
 "<A href='?src=\ref[src];operation=weaponscheck'>[weaponscheck ? "Yes" : "No"]</A>",
 "<A href='?src=\ref[src];operation=ignorerec'>[check_records ? "Yes" : "No"]</A>",
-"<A href='?src=\ref[src];operation=switchmode'>[arrest_type ? "Detain" : "Arrest"]</A>",
 "<A href='?src=\ref[src];operation=declarearrests'>[declare_arrests ? "Yes" : "No"]</A>",
 "<A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>" )
 
@@ -129,9 +127,6 @@ Auto Patrol: []"},
 			update_controls()
 		if("ignorerec")
 			check_records = !check_records
-			update_controls()
-		if("switchmode")
-			arrest_type = !arrest_type
 			update_controls()
 		if("declarearrests")
 			declare_arrests = !declare_arrests
@@ -180,7 +175,7 @@ Auto Patrol: []"},
 		return
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
-		if(!C.stunned || arrest_type)
+		if(!C.stunned)
 			stun_attack(A)
 		else if(C.canBeHandcuffed() && !C.handcuffed)
 			cuff(A)
@@ -231,7 +226,7 @@ Auto Patrol: []"},
 	add_logs(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
-		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+		speak("Arresting level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
 	C.visible_message("<span class='danger'>[src] has stunned [C]!</span>",\
 							"<span class='userdanger'>[src] has stunned you!</span>")
 
@@ -283,8 +278,7 @@ Auto Patrol: []"},
 				return
 
 			if(iscarbon(target) && target.canBeHandcuffed())
-				if(!arrest_type)
-					if(!target.handcuffed)  //he's not cuffed? Try to cuff him!
+				if(!target.handcuffed)  //he's not cuffed? Try to cuff him!
 						cuff(target)
 					else
 						back_to_idle()


### PR DESCRIPTION
:cl: PopNotes
tweak: Standard secbots can no longer detain whereas ED-209s can.

/:cl:

