### PR TITLE
Buffs Clown Shoes

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -75,7 +75,6 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
 	var/footstep = 1	//used for squeeks whilst walking
 	pockets = /obj/item/weapon/storage/internal/pocket/shoes/clown


### PR DESCRIPTION
:cl: PopNotes
tweak: Nanotrasen has developed clown shoes that no longer slow you down. Now, you can move yo fat body freery.
/:cl:

For so long, many clowns have chosen to take off their shoes in favor of ones that do not slow them down, but do not squeak either. With this very, very important PR, I take responsibility in hand and give clowns the proper buff they deserve.